### PR TITLE
Reset page control center when textLabelShow is changed.

### DIFF
--- a/PFCarouselView/PFCarouselView.m
+++ b/PFCarouselView/PFCarouselView.m
@@ -244,6 +244,7 @@ typedef void (^tapBlock)(NSInteger);
 {
     _textLabelShow = textLabelShow;
     if (!textLabelShow) [_textLabel removeFromSuperview], _textLabel = nil;
+    _pageControl.center = CGPointMake(_scrollView.center.x, _scrollView.bounds.size.height - (textLabelShow ? 40 : 10));
 }
 
 #pragma mark - Private Methods


### PR DESCRIPTION
当 Text Label 不显示的时候， Page Control 小白点离底部太远了，稍微修改了一下。
